### PR TITLE
Fix build after LibGUI changes

### DIFF
--- a/doomgeneric/doomgeneric_serenity.cpp
+++ b/doomgeneric/doomgeneric_serenity.cpp
@@ -130,12 +130,12 @@ extern "C" void DG_Init()
     auto app_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/doom.png"sv).release_value_but_fixme_should_propagate_errors();
     g_window->set_icon(app_icon);
 
-    auto& doom_menu = g_window->add_menu("DOOM");
+    auto& doom_menu = g_window->add_menu("DOOM"_short_string);
     doom_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         exit(0);
     }));
 
-    auto& view_menu = g_window->add_menu("View");
+    auto& view_menu = g_window->add_menu("View"_short_string);
     auto fullscreen_action = GUI::CommonActions::make_fullscreen_action([&](auto& action) {
         action.set_checked(!action.is_checked());
         DG_SetFullscreen(action.is_checked());

--- a/doomgeneric/i_main.cpp
+++ b/doomgeneric/i_main.cpp
@@ -18,9 +18,12 @@
 
 //#include "config.h"
 
+#include <AK/StringView.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
+#include <LibMain/Main.h>
 
+#include <string.h>
 #include <stdio.h>
 
 extern "C" {
@@ -45,7 +48,12 @@ void DG_SetFullscreen(bool);
 
 int main(int argc, char** argv)
 {
-    auto app = GUI::Application::construct(argc, argv);
+    Vector<StringView> arguments;
+    arguments.ensure_capacity(argc);
+    for (int i = 0; i < argc; ++i)
+        arguments.unchecked_append({ argv[i], strlen(argv[i]) });
+
+    auto app = GUI::Application::create(Main::Arguments { argc, argv, arguments.span() });
 
     // save arguments
 


### PR DESCRIPTION
This PR fixes the build after changes to LibGUI.

NB: The Doom port is currently also missing a valid sha256 checksum, but I can't add that until this change is merged.